### PR TITLE
Assert expected file contents in integration test

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -11,7 +11,6 @@ jobs:
     strategy:
       matrix:
         os: [ ubuntu-latest, windows-latest, macos-latest ]
-#        os: [ windows-latest ]
     steps:
       - name: Checkout code
         uses: actions/checkout@v2.4.0

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -11,6 +11,7 @@ jobs:
     strategy:
       matrix:
         os: [ ubuntu-latest, windows-latest, macos-latest ]
+#        os: [ windows-latest ]
     steps:
       - name: Checkout code
         uses: actions/checkout@v2.4.0

--- a/.github/workflows/integration-test.yml
+++ b/.github/workflows/integration-test.yml
@@ -10,7 +10,8 @@ jobs:
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
-        os: [ ubuntu-latest, windows-latest, macos-latest ]
+#        os: [ ubuntu-latest, windows-latest, macos-latest ]
+        os: [ windows-latest ]
     steps:
       - name: Checkout code
         uses: actions/checkout@v2.4.0

--- a/.github/workflows/integration-test.yml
+++ b/.github/workflows/integration-test.yml
@@ -10,8 +10,7 @@ jobs:
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
-        #        os: [ ubuntu-latest, windows-latest, macos-latest ]
-        os: [ windows-latest ]
+        os: [ ubuntu-latest, windows-latest, macos-latest ]
     steps:
       - name: Checkout code
         uses: actions/checkout@v2.4.0
@@ -41,6 +40,9 @@ jobs:
         if: matrix.os == 'macos-latest'
         run: brew install handbrake
 
+      # Need to generate encoded file for the integration tests on the GitHub Actions agent.
+      # Can't simply use the one stored in git, guessing different hardware etc. results in slightly
+      # different output.
       - name: Generate test data
         run: |
           HandBrakeCLI --preset "Production Standard" -i nvidia-shadowplay/src/integrationTest/resources/Big_Buck_Bunny_360_10s_1MB.mp4 -o nvidia-shadowplay/src/integrationTest/resources/Big_Buck_Bunny_360_10s_1MB_encoded_Production_Standard.mp4

--- a/.github/workflows/integration-test.yml
+++ b/.github/workflows/integration-test.yml
@@ -10,7 +10,7 @@ jobs:
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
-#        os: [ ubuntu-latest, windows-latest, macos-latest ]
+        #        os: [ ubuntu-latest, windows-latest, macos-latest ]
         os: [ windows-latest ]
     steps:
       - name: Checkout code
@@ -40,6 +40,10 @@ jobs:
       - name: Setup HandBrake (Mac)
         if: matrix.os == 'macos-latest'
         run: brew install handbrake
+
+      - name: Generate test data
+        run: |
+          HandBrakeCLI --preset "Production Standard" -i nvidia-shadowplay/src/integrationTest/resources/Big_Buck_Bunny_360_10s_1MB.mp4 -o nvidia-shadowplay/src/integrationTest/resources/Big_Buck_Bunny_360_10s_1MB_encoded_Production_Standard.mp4
 
       - name: Grant execute permission for gradlew
         run: chmod +x gradlew

--- a/nvidia-shadowplay/src/integrationTest/java/com/wilmol/handbrake/nvidia/shadowplay/AppIntegrationTest.java
+++ b/nvidia-shadowplay/src/integrationTest/java/com/wilmol/handbrake/nvidia/shadowplay/AppIntegrationTest.java
@@ -67,7 +67,7 @@ class AppIntegrationTest {
     assertThatTestDirectory()
         .containsExactly(
             // encoding
-            new PathAndContents(inputDirectory.resolve("my video - CFR.mp4"), testVideo),
+            new PathAndContents(inputDirectory.resolve("my video - CFR.mp4"), testVideoEncoded),
             // archive
             new PathAndContents(inputDirectory.resolve("my video - Archived.mp4"), testVideo));
   }

--- a/nvidia-shadowplay/src/integrationTest/java/com/wilmol/handbrake/nvidia/shadowplay/AppIntegrationTest.java
+++ b/nvidia-shadowplay/src/integrationTest/java/com/wilmol/handbrake/nvidia/shadowplay/AppIntegrationTest.java
@@ -828,33 +828,28 @@ class AppIntegrationTest {
         Boolean.FALSE.toString());
   }
 
-  private IterableSubject.UsingCorrespondence<PathAndContents, PathAndContents>
-      assertThatTestDirectory() throws IOException {
-    return assertThat(
-            Files.walk(testDirectory)
-                .filter(Files::isRegularFile)
-                .map(path -> new PathAndContents(path, path))
-                .toList())
+  private IterableSubject.UsingCorrespondence<Path, PathAndContents> assertThatTestDirectory()
+      throws IOException {
+    return assertThat(Files.walk(testDirectory).filter(Files::isRegularFile).toList())
         .comparingElementsUsing(PathAndContents.correspondence());
   }
 
   private record PathAndContents(Path path, Path contents) {
 
-    static Correspondence<PathAndContents, PathAndContents> correspondence() {
+    static Correspondence<Path, PathAndContents> correspondence() {
       return Correspondence.from(PathAndContents::recordsEquivalent, "is equivalent to")
           .formattingDiffsUsing(PathAndContents::formatRecordDiff);
     }
 
-    static boolean recordsEquivalent(PathAndContents actual, PathAndContents expected) {
-      return actual.path.equals(expected.path)
-          && contentsSimilar(actual.contents, expected.contents);
+    static boolean recordsEquivalent(Path actual, PathAndContents expected) {
+      return actual.equals(expected.path) && contentsSimilar(actual, expected.contents);
     }
 
-    static String formatRecordDiff(PathAndContents actual, PathAndContents expected) {
-      if (!actual.path.equals(expected.path)) {
+    static String formatRecordDiff(Path actual, PathAndContents expected) {
+      if (!actual.equals(expected.path)) {
         return "paths not equal";
       }
-      if (!contentsSimilar(actual.path, expected.path)) {
+      if (!contentsSimilar(actual, expected.path)) {
         return "contents not similar";
       }
       throw new AssertionError("Unreachable");

--- a/nvidia-shadowplay/src/integrationTest/java/com/wilmol/handbrake/nvidia/shadowplay/AppIntegrationTest.java
+++ b/nvidia-shadowplay/src/integrationTest/java/com/wilmol/handbrake/nvidia/shadowplay/AppIntegrationTest.java
@@ -1,14 +1,19 @@
 package com.wilmol.handbrake.nvidia.shadowplay;
 
 import static com.google.common.base.Preconditions.checkNotNull;
-import static com.google.common.truth.Truth8.assertThat;
+import static com.google.common.truth.Truth.assertThat;
 
+import com.google.common.collect.Lists;
 import com.google.common.io.Resources;
-import com.google.common.truth.StreamSubject;
+import com.google.common.truth.Correspondence;
+import com.google.common.truth.IterableSubject;
 import com.google.errorprone.annotations.CanIgnoreReturnValue;
 import java.io.IOException;
+import java.io.UncheckedIOException;
 import java.nio.file.Files;
 import java.nio.file.Path;
+import java.util.Arrays;
+
 import org.apache.commons.io.FileUtils;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
@@ -29,12 +34,14 @@ class AppIntegrationTest {
 
   private Path testDirectory;
   private Path testVideo;
+  private Path testVideoEncoded;
   private Path testVideo2;
 
   @BeforeEach
   void setUp() throws Exception {
     testDirectory = Path.of(this.getClass().getSimpleName());
     testVideo = Path.of(Resources.getResource("Big_Buck_Bunny_360_10s_1MB.mp4").toURI());
+    testVideoEncoded = Path.of(Resources.getResource("Big_Buck_Bunny_360_10s_1MB_encoded_Production_Standard.mp4").toURI());
     testVideo2 = Path.of(Resources.getResource("Big_Buck_Bunny_360_10s_2MB.mp4").toURI());
   }
 
@@ -49,7 +56,7 @@ class AppIntegrationTest {
     // Given
     // video to encode
     Path inputDirectory = createDirectoryAt(testDirectory.resolve("Gameplay"));
-    createVideoAt(inputDirectory.resolve("my video.mp4"));
+    createVideoAt(inputDirectory.resolve("my video.mp4"), testVideo);
 
     // When
     runApp(inputDirectory, inputDirectory, inputDirectory);
@@ -58,9 +65,9 @@ class AppIntegrationTest {
     assertThatTestDirectory()
         .containsExactly(
             // encoding
-            inputDirectory.resolve("my video - CFR.mp4"),
+            new PathAndContents(inputDirectory.resolve("my video - CFR.mp4"), testVideoEncoded),
             // archive
-            inputDirectory.resolve("my video - Archived.mp4"));
+            new PathAndContents(inputDirectory.resolve("my video - Archived.mp4"), testVideo));
   }
 
   @Test
@@ -69,7 +76,7 @@ class AppIntegrationTest {
     // Given
     // video to encode
     Path inputDirectory = createDirectoryAt(testDirectory.resolve("Gameplay"));
-    createVideoAt(inputDirectory.resolve("recording.mp4"));
+    createVideoAt(inputDirectory.resolve("recording.mp4"), testVideo);
 
     Path outputDirectory = createDirectoryAt(testDirectory.resolve("Gameplay Encoded"));
 
@@ -80,9 +87,9 @@ class AppIntegrationTest {
     assertThatTestDirectory()
         .containsExactly(
             // encoding
-            outputDirectory.resolve("recording - CFR.mp4"),
+            new PathAndContents(outputDirectory.resolve("recording - CFR.mp4"), testVideoEncoded),
             // archive
-            inputDirectory.resolve("recording - Archived.mp4"));
+            new PathAndContents(inputDirectory.resolve("recording - Archived.mp4"), testVideo));
   }
 
   @Test
@@ -91,7 +98,7 @@ class AppIntegrationTest {
     // Given
     // video to encode
     Path inputDirectory = createDirectoryAt(testDirectory.resolve("Gameplay"));
-    createVideoAt(inputDirectory.resolve("vid1.mp4"));
+    createVideoAt(inputDirectory.resolve("vid1.mp4"), testVideo);
 
     Path archiveDirectory = createDirectoryAt(testDirectory.resolve("Gameplay Archive"));
 
@@ -102,9 +109,9 @@ class AppIntegrationTest {
     assertThatTestDirectory()
         .containsExactly(
             // encoding
-            inputDirectory.resolve("vid1 - CFR.mp4"),
+            new PathAndContents(inputDirectory.resolve("vid1 - CFR.mp4"), testVideoEncoded),
             // archive
-            archiveDirectory.resolve("vid1 - Archived.mp4"));
+            new PathAndContents(archiveDirectory.resolve("vid1 - Archived.mp4"), testVideo));
   }
 
   @Test
@@ -113,7 +120,7 @@ class AppIntegrationTest {
     // Given
     // video to encode
     Path inputDirectory = createDirectoryAt(testDirectory.resolve("Gameplay"));
-    createVideoAt(inputDirectory.resolve("recording1.mp4"));
+    createVideoAt(inputDirectory.resolve("recording1.mp4"), testVideo);
 
     Path outputDirectory = createDirectoryAt(testDirectory.resolve("Gameplay Encoded"));
 
@@ -126,9 +133,9 @@ class AppIntegrationTest {
     assertThatTestDirectory()
         .containsExactly(
             // encoding
-            outputDirectory.resolve("recording1 - CFR.mp4"),
+            new PathAndContents(outputDirectory.resolve("recording1 - CFR.mp4"), testVideoEncoded),
             // archive
-            archiveDirectory.resolve("recording1 - Archived.mp4"));
+            new PathAndContents(archiveDirectory.resolve("recording1 - Archived.mp4"), testVideo));
   }
 
   @Test
@@ -137,7 +144,7 @@ class AppIntegrationTest {
     // Given
     // video to encode
     Path inputDirectory = createDirectoryAt(testDirectory.resolve("Gameplay"));
-    createVideoAt(inputDirectory.resolve("League of Legends/ranked_game1.mp4"));
+    createVideoAt(inputDirectory.resolve("League of Legends/ranked_game1.mp4"), testVideo);
 
     // When
     runApp(inputDirectory, inputDirectory, inputDirectory);
@@ -146,9 +153,12 @@ class AppIntegrationTest {
     assertThatTestDirectory()
         .containsExactly(
             // encoding
-            inputDirectory.resolve("League of Legends/ranked_game1 - CFR.mp4"),
+            new PathAndContents(
+                inputDirectory.resolve("League of Legends/ranked_game1 - CFR.mp4"), testVideoEncoded),
             // archive
-            inputDirectory.resolve("League of Legends/ranked_game1 - Archived.mp4"));
+            new PathAndContents(
+                inputDirectory.resolve("League of Legends/ranked_game1 - Archived.mp4"),
+                testVideo));
   }
 
   @Test
@@ -157,7 +167,7 @@ class AppIntegrationTest {
     // Given
     // video to encode
     Path inputDirectory = createDirectoryAt(testDirectory.resolve("Gameplay"));
-    createVideoAt(inputDirectory.resolve("StarCraft II/protoss.mp4"));
+    createVideoAt(inputDirectory.resolve("StarCraft II/protoss.mp4"), testVideo);
 
     Path outputDirectory = createDirectoryAt(testDirectory.resolve("Gameplay Encoded"));
 
@@ -168,9 +178,11 @@ class AppIntegrationTest {
     assertThatTestDirectory()
         .containsExactly(
             // encoding
-            outputDirectory.resolve("StarCraft II/protoss - CFR.mp4"),
+            new PathAndContents(
+                outputDirectory.resolve("StarCraft II/protoss - CFR.mp4"), testVideoEncoded),
             // archive
-            inputDirectory.resolve("StarCraft II/protoss - Archived.mp4"));
+            new PathAndContents(
+                inputDirectory.resolve("StarCraft II/protoss - Archived.mp4"), testVideo));
   }
 
   @Test
@@ -179,7 +191,7 @@ class AppIntegrationTest {
     // Given
     // video to encode
     Path inputDirectory = createDirectoryAt(testDirectory.resolve("Gameplay"));
-    createVideoAt(inputDirectory.resolve("Path of Exile/vaal spark templar.mp4"));
+    createVideoAt(inputDirectory.resolve("Path of Exile/vaal spark templar.mp4"), testVideo);
 
     Path archiveDirectory = createDirectoryAt(testDirectory.resolve("Gameplay Archive"));
 
@@ -190,9 +202,12 @@ class AppIntegrationTest {
     assertThatTestDirectory()
         .containsExactly(
             // encoding
-            inputDirectory.resolve("Path of Exile/vaal spark templar - CFR.mp4"),
+            new PathAndContents(
+                inputDirectory.resolve("Path of Exile/vaal spark templar - CFR.mp4"), testVideoEncoded),
             // archive
-            archiveDirectory.resolve("Path of Exile/vaal spark templar - Archived.mp4"));
+            new PathAndContents(
+                archiveDirectory.resolve("Path of Exile/vaal spark templar - Archived.mp4"),
+                testVideo));
   }
 
   @Test
@@ -202,7 +217,8 @@ class AppIntegrationTest {
     // Given
     // video to encode
     Path inputDirectory = createDirectoryAt(testDirectory.resolve("Gameplay"));
-    createVideoAt(inputDirectory.resolve("Halo Infinite/Legendary Campaign/1st mission.mp4"));
+    createVideoAt(
+        inputDirectory.resolve("Halo Infinite/Legendary Campaign/1st mission.mp4"), testVideo);
 
     Path outputDirectory = createDirectoryAt(testDirectory.resolve("Gameplay Encoded"));
 
@@ -215,10 +231,14 @@ class AppIntegrationTest {
     assertThatTestDirectory()
         .containsExactly(
             // encoding
-            outputDirectory.resolve("Halo Infinite/Legendary Campaign/1st mission - CFR.mp4"),
+            new PathAndContents(
+                outputDirectory.resolve("Halo Infinite/Legendary Campaign/1st mission - CFR.mp4"),
+                testVideoEncoded),
             // archive
-            archiveDirectory.resolve(
-                "Halo Infinite/Legendary Campaign/1st mission - Archived.mp4"));
+            new PathAndContents(
+                archiveDirectory.resolve(
+                    "Halo Infinite/Legendary Campaign/1st mission - Archived.mp4"),
+                testVideo));
   }
 
   @Test
@@ -227,10 +247,10 @@ class AppIntegrationTest {
     // Given
     // videos to encode
     Path inputDirectory = createDirectoryAt(testDirectory.resolve("Gameplay"));
-    createVideoAt(inputDirectory.resolve("recording1.mp4"));
-    createVideoAt(inputDirectory.resolve("recording2.mp4"));
-    createVideoAt(inputDirectory.resolve("Nested/recording3.mp4"));
-    createVideoAt(inputDirectory.resolve("Nested1/Nested2/recording4.mp4"));
+    createVideoAt(inputDirectory.resolve("recording1.mp4"), testVideo);
+    createVideoAt(inputDirectory.resolve("recording2.mp4"), testVideo);
+    createVideoAt(inputDirectory.resolve("Nested/recording3.mp4"), testVideo);
+    createVideoAt(inputDirectory.resolve("Nested1/Nested2/recording4.mp4"), testVideo);
 
     // When
     runApp(inputDirectory, inputDirectory, inputDirectory);
@@ -239,15 +259,18 @@ class AppIntegrationTest {
     assertThatTestDirectory()
         .containsExactly(
             // encodings
-            inputDirectory.resolve("recording1 - CFR.mp4"),
-            inputDirectory.resolve("recording2 - CFR.mp4"),
-            inputDirectory.resolve("Nested/recording3 - CFR.mp4"),
-            inputDirectory.resolve("Nested1/Nested2/recording4 - CFR.mp4"),
+            new PathAndContents(inputDirectory.resolve("recording1 - CFR.mp4"), testVideoEncoded),
+            new PathAndContents(inputDirectory.resolve("recording2 - CFR.mp4"), testVideoEncoded),
+            new PathAndContents(inputDirectory.resolve("Nested/recording3 - CFR.mp4"), testVideoEncoded),
+            new PathAndContents(
+                inputDirectory.resolve("Nested1/Nested2/recording4 - CFR.mp4"), testVideoEncoded),
             // archives
-            inputDirectory.resolve("recording1 - Archived.mp4"),
-            inputDirectory.resolve("recording2 - Archived.mp4"),
-            inputDirectory.resolve("Nested/recording3 - Archived.mp4"),
-            inputDirectory.resolve("Nested1/Nested2/recording4 - Archived.mp4"));
+            new PathAndContents(inputDirectory.resolve("recording1 - Archived.mp4"), testVideo),
+            new PathAndContents(inputDirectory.resolve("recording2 - Archived.mp4"), testVideo),
+            new PathAndContents(
+                inputDirectory.resolve("Nested/recording3 - Archived.mp4"), testVideo),
+            new PathAndContents(
+                inputDirectory.resolve("Nested1/Nested2/recording4 - Archived.mp4"), testVideo));
   }
 
   @Test
@@ -256,10 +279,10 @@ class AppIntegrationTest {
     // Given
     // videos to encode
     Path inputDirectory = createDirectoryAt(testDirectory.resolve("Gameplay"));
-    createVideoAt(inputDirectory.resolve("recording1.mp4"));
-    createVideoAt(inputDirectory.resolve("recording2.mp4"));
-    createVideoAt(inputDirectory.resolve("Nested/recording3.mp4"));
-    createVideoAt(inputDirectory.resolve("Nested1/Nested2/recording4.mp4"));
+    createVideoAt(inputDirectory.resolve("recording1.mp4"), testVideo);
+    createVideoAt(inputDirectory.resolve("recording2.mp4"), testVideo);
+    createVideoAt(inputDirectory.resolve("Nested/recording3.mp4"), testVideo);
+    createVideoAt(inputDirectory.resolve("Nested1/Nested2/recording4.mp4"), testVideo);
 
     Path outputDirectory = createDirectoryAt(testDirectory.resolve("Gameplay Encoded"));
 
@@ -270,15 +293,18 @@ class AppIntegrationTest {
     assertThatTestDirectory()
         .containsExactly(
             // encodings
-            outputDirectory.resolve("recording1 - CFR.mp4"),
-            outputDirectory.resolve("recording2 - CFR.mp4"),
-            outputDirectory.resolve("Nested/recording3 - CFR.mp4"),
-            outputDirectory.resolve("Nested1/Nested2/recording4 - CFR.mp4"),
+            new PathAndContents(outputDirectory.resolve("recording1 - CFR.mp4"), testVideoEncoded),
+            new PathAndContents(outputDirectory.resolve("recording2 - CFR.mp4"), testVideoEncoded),
+            new PathAndContents(outputDirectory.resolve("Nested/recording3 - CFR.mp4"), testVideoEncoded),
+            new PathAndContents(
+                outputDirectory.resolve("Nested1/Nested2/recording4 - CFR.mp4"), testVideoEncoded),
             // archives
-            inputDirectory.resolve("recording1 - Archived.mp4"),
-            inputDirectory.resolve("recording2 - Archived.mp4"),
-            inputDirectory.resolve("Nested/recording3 - Archived.mp4"),
-            inputDirectory.resolve("Nested1/Nested2/recording4 - Archived.mp4"));
+            new PathAndContents(inputDirectory.resolve("recording1 - Archived.mp4"), testVideo),
+            new PathAndContents(inputDirectory.resolve("recording2 - Archived.mp4"), testVideo),
+            new PathAndContents(
+                inputDirectory.resolve("Nested/recording3 - Archived.mp4"), testVideo),
+            new PathAndContents(
+                inputDirectory.resolve("Nested1/Nested2/recording4 - Archived.mp4"), testVideo));
   }
 
   @Test
@@ -287,10 +313,10 @@ class AppIntegrationTest {
     // Given
     // videos to encode
     Path inputDirectory = createDirectoryAt(testDirectory.resolve("Gameplay"));
-    createVideoAt(inputDirectory.resolve("recording1.mp4"));
-    createVideoAt(inputDirectory.resolve("recording2.mp4"));
-    createVideoAt(inputDirectory.resolve("Nested/recording3.mp4"));
-    createVideoAt(inputDirectory.resolve("Nested1/Nested2/recording4.mp4"));
+    createVideoAt(inputDirectory.resolve("recording1.mp4"), testVideo);
+    createVideoAt(inputDirectory.resolve("recording2.mp4"), testVideo);
+    createVideoAt(inputDirectory.resolve("Nested/recording3.mp4"), testVideo);
+    createVideoAt(inputDirectory.resolve("Nested1/Nested2/recording4.mp4"), testVideo);
 
     Path archiveDirectory = createDirectoryAt(testDirectory.resolve("Gameplay Archive"));
 
@@ -301,15 +327,18 @@ class AppIntegrationTest {
     assertThatTestDirectory()
         .containsExactly(
             // encodings
-            inputDirectory.resolve("recording1 - CFR.mp4"),
-            inputDirectory.resolve("recording2 - CFR.mp4"),
-            inputDirectory.resolve("Nested/recording3 - CFR.mp4"),
-            inputDirectory.resolve("Nested1/Nested2/recording4 - CFR.mp4"),
+            new PathAndContents(inputDirectory.resolve("recording1 - CFR.mp4"), testVideoEncoded),
+            new PathAndContents(inputDirectory.resolve("recording2 - CFR.mp4"), testVideoEncoded),
+            new PathAndContents(inputDirectory.resolve("Nested/recording3 - CFR.mp4"), testVideoEncoded),
+            new PathAndContents(
+                inputDirectory.resolve("Nested1/Nested2/recording4 - CFR.mp4"), testVideoEncoded),
             // archives
-            archiveDirectory.resolve("recording1 - Archived.mp4"),
-            archiveDirectory.resolve("recording2 - Archived.mp4"),
-            archiveDirectory.resolve("Nested/recording3 - Archived.mp4"),
-            archiveDirectory.resolve("Nested1/Nested2/recording4 - Archived.mp4"));
+            new PathAndContents(archiveDirectory.resolve("recording1 - Archived.mp4"), testVideo),
+            new PathAndContents(archiveDirectory.resolve("recording2 - Archived.mp4"), testVideo),
+            new PathAndContents(
+                archiveDirectory.resolve("Nested/recording3 - Archived.mp4"), testVideo),
+            new PathAndContents(
+                archiveDirectory.resolve("Nested1/Nested2/recording4 - Archived.mp4"), testVideo));
   }
 
   @Test
@@ -319,10 +348,10 @@ class AppIntegrationTest {
     // Given
     // videos to encode
     Path inputDirectory = createDirectoryAt(testDirectory.resolve("Gameplay"));
-    createVideoAt(inputDirectory.resolve("recording1.mp4"));
-    createVideoAt(inputDirectory.resolve("recording2.mp4"));
-    createVideoAt(inputDirectory.resolve("Nested/recording3.mp4"));
-    createVideoAt(inputDirectory.resolve("Nested1/Nested2/recording4.mp4"));
+    createVideoAt(inputDirectory.resolve("recording1.mp4"), testVideo);
+    createVideoAt(inputDirectory.resolve("recording2.mp4"), testVideo);
+    createVideoAt(inputDirectory.resolve("Nested/recording3.mp4"), testVideo);
+    createVideoAt(inputDirectory.resolve("Nested1/Nested2/recording4.mp4"), testVideo);
 
     Path outputDirectory = createDirectoryAt(testDirectory.resolve("Gameplay Encoded"));
 
@@ -335,15 +364,18 @@ class AppIntegrationTest {
     assertThatTestDirectory()
         .containsExactly(
             // encodings
-            outputDirectory.resolve("recording1 - CFR.mp4"),
-            outputDirectory.resolve("recording2 - CFR.mp4"),
-            outputDirectory.resolve("Nested/recording3 - CFR.mp4"),
-            outputDirectory.resolve("Nested1/Nested2/recording4 - CFR.mp4"),
+            new PathAndContents(outputDirectory.resolve("recording1 - CFR.mp4"), testVideoEncoded),
+            new PathAndContents(outputDirectory.resolve("recording2 - CFR.mp4"), testVideoEncoded),
+            new PathAndContents(outputDirectory.resolve("Nested/recording3 - CFR.mp4"), testVideoEncoded),
+            new PathAndContents(
+                outputDirectory.resolve("Nested1/Nested2/recording4 - CFR.mp4"), testVideoEncoded),
             // archives
-            archiveDirectory.resolve("recording1 - Archived.mp4"),
-            archiveDirectory.resolve("recording2 - Archived.mp4"),
-            archiveDirectory.resolve("Nested/recording3 - Archived.mp4"),
-            archiveDirectory.resolve("Nested1/Nested2/recording4 - Archived.mp4"));
+            new PathAndContents(archiveDirectory.resolve("recording1 - Archived.mp4"), testVideo),
+            new PathAndContents(archiveDirectory.resolve("recording2 - Archived.mp4"), testVideo),
+            new PathAndContents(
+                archiveDirectory.resolve("Nested/recording3 - Archived.mp4"), testVideo),
+            new PathAndContents(
+                archiveDirectory.resolve("Nested1/Nested2/recording4 - Archived.mp4"), testVideo));
   }
 
   @Test
@@ -352,15 +384,15 @@ class AppIntegrationTest {
     // Given
     // video to encode
     Path inputDirectory = createDirectoryAt(testDirectory.resolve("Gameplay"));
-    createVideoAt(inputDirectory.resolve("my video.mp4"));
+    createVideoAt(inputDirectory.resolve("my video.mp4"), testVideo);
 
     // incomplete encodings
-    createVideoAt(inputDirectory.resolve("recording - CFR (incomplete).mp4"));
-    createVideoAt(inputDirectory.resolve("recording2 - CFR (incomplete).mp4"));
+    createVideoAt(inputDirectory.resolve("recording - CFR (incomplete).mp4"), testVideo);
+    createVideoAt(inputDirectory.resolve("recording2 - CFR (incomplete).mp4"), testVideo);
 
     // incomplete archives
-    createVideoAt(inputDirectory.resolve("vid - Archived (incomplete).mp4"));
-    createVideoAt(inputDirectory.resolve("vid2 - Archived (incomplete).mp4"));
+    createVideoAt(inputDirectory.resolve("vid - Archived (incomplete).mp4"), testVideo);
+    createVideoAt(inputDirectory.resolve("vid2 - Archived (incomplete).mp4"), testVideo);
 
     // When
     runApp(inputDirectory, inputDirectory, inputDirectory);
@@ -369,9 +401,9 @@ class AppIntegrationTest {
     assertThatTestDirectory()
         .containsExactly(
             // encoding
-            inputDirectory.resolve("my video - CFR.mp4"),
+            new PathAndContents(inputDirectory.resolve("my video - CFR.mp4"), testVideoEncoded),
             // archive
-            inputDirectory.resolve("my video - Archived.mp4"));
+            new PathAndContents(inputDirectory.resolve("my video - Archived.mp4"), testVideo));
   }
 
   @Test
@@ -382,21 +414,21 @@ class AppIntegrationTest {
     // Given
     // video to encode
     Path inputDirectory = createDirectoryAt(testDirectory.resolve("Gameplay"));
-    createVideoAt(inputDirectory.resolve("my video.mp4"));
+    createVideoAt(inputDirectory.resolve("my video.mp4"), testVideo);
 
     Path outputDirectory = createDirectoryAt(testDirectory.resolve("Gameplay Encoded"));
 
     Path archiveDirectory = createDirectoryAt(testDirectory.resolve("Gameplay Archive"));
 
     // incomplete encodings
-    createVideoAt(inputDirectory.resolve("recording - CFR (incomplete).mp4"));
-    createVideoAt(outputDirectory.resolve("recording - CFR (incomplete).mp4"));
-    createVideoAt(archiveDirectory.resolve("recording - CFR (incomplete).mp4"));
+    createVideoAt(inputDirectory.resolve("recording - CFR (incomplete).mp4"), testVideo);
+    createVideoAt(outputDirectory.resolve("recording - CFR (incomplete).mp4"), testVideo);
+    createVideoAt(archiveDirectory.resolve("recording - CFR (incomplete).mp4"), testVideo);
 
     // incomplete archives
-    createVideoAt(inputDirectory.resolve("vid - Archived (incomplete).mp4"));
-    createVideoAt(outputDirectory.resolve("vid - Archived (incomplete).mp4"));
-    createVideoAt(archiveDirectory.resolve("vid - Archived (incomplete).mp4"));
+    createVideoAt(inputDirectory.resolve("vid - Archived (incomplete).mp4"), testVideo);
+    createVideoAt(outputDirectory.resolve("vid - Archived (incomplete).mp4"), testVideo);
+    createVideoAt(archiveDirectory.resolve("vid - Archived (incomplete).mp4"), testVideo);
 
     // When
     runApp(inputDirectory, outputDirectory, archiveDirectory);
@@ -405,9 +437,9 @@ class AppIntegrationTest {
     assertThatTestDirectory()
         .containsExactly(
             // encoding
-            outputDirectory.resolve("my video - CFR.mp4"),
+            new PathAndContents(outputDirectory.resolve("my video - CFR.mp4"), testVideoEncoded),
             // archive
-            archiveDirectory.resolve("my video - Archived.mp4"));
+            new PathAndContents(archiveDirectory.resolve("my video - Archived.mp4"), testVideo));
   }
 
   @Test
@@ -416,15 +448,15 @@ class AppIntegrationTest {
     // Given
     // video to encode
     Path inputDirectory = createDirectoryAt(testDirectory.resolve("Gameplay"));
-    createVideoAt(inputDirectory.resolve("my video.mp4"));
+    createVideoAt(inputDirectory.resolve("my video.mp4"), testVideo);
 
     // unrelated encodings
-    createVideoAt(inputDirectory.resolve("recording - CFR.mp4"));
-    createVideoAt(inputDirectory.resolve("recording2 - CFR.mp4"));
+    createVideoAt(inputDirectory.resolve("recording - CFR.mp4"), testVideo);
+    createVideoAt(inputDirectory.resolve("recording2 - CFR.mp4"), testVideo);
 
     // unrelated archives
-    createVideoAt(inputDirectory.resolve("recording - Archived.mp4"));
-    createVideoAt(inputDirectory.resolve("recording2 - Archived.mp4"));
+    createVideoAt(inputDirectory.resolve("recording - Archived.mp4"), testVideo);
+    createVideoAt(inputDirectory.resolve("recording2 - Archived.mp4"), testVideo);
 
     // When
     runApp(inputDirectory, inputDirectory, inputDirectory);
@@ -433,15 +465,15 @@ class AppIntegrationTest {
     assertThatTestDirectory()
         .containsExactly(
             // encoding
-            inputDirectory.resolve("my video - CFR.mp4"),
+            new PathAndContents(inputDirectory.resolve("my video - CFR.mp4"), testVideoEncoded),
             // archive
-            inputDirectory.resolve("my video - Archived.mp4"),
+            new PathAndContents(inputDirectory.resolve("my video - Archived.mp4"), testVideo),
             // unrelated encodings
-            inputDirectory.resolve("recording - CFR.mp4"),
-            inputDirectory.resolve("recording2 - CFR.mp4"),
+            new PathAndContents(inputDirectory.resolve("recording - CFR.mp4"), testVideoEncoded),
+            new PathAndContents(inputDirectory.resolve("recording2 - CFR.mp4"), testVideoEncoded),
             // unrelated archives
-            inputDirectory.resolve("recording - Archived.mp4"),
-            inputDirectory.resolve("recording2 - Archived.mp4"));
+            new PathAndContents(inputDirectory.resolve("recording - Archived.mp4"), testVideo),
+            new PathAndContents(inputDirectory.resolve("recording2 - Archived.mp4"), testVideo));
   }
 
   @Test
@@ -452,21 +484,21 @@ class AppIntegrationTest {
     // Given
     // video to encode
     Path inputDirectory = createDirectoryAt(testDirectory.resolve("Gameplay"));
-    createVideoAt(inputDirectory.resolve("my video.mp4"));
+    createVideoAt(inputDirectory.resolve("my video.mp4"), testVideo);
 
     Path outputDirectory = createDirectoryAt(testDirectory.resolve("Gameplay Encoded"));
 
     Path archiveDirectory = createDirectoryAt(testDirectory.resolve("Gameplay Archive"));
 
     // unrelated encodings
-    createVideoAt(inputDirectory.resolve("recording - CFR.mp4"));
-    createVideoAt(outputDirectory.resolve("recording - CFR.mp4"));
-    createVideoAt(archiveDirectory.resolve("recording - CFR.mp4"));
+    createVideoAt(inputDirectory.resolve("recording - CFR.mp4"), testVideoEncoded);
+    createVideoAt(outputDirectory.resolve("recording - CFR.mp4"), testVideoEncoded);
+    createVideoAt(archiveDirectory.resolve("recording - CFR.mp4"), testVideoEncoded);
 
     // unrelated archives
-    createVideoAt(inputDirectory.resolve("recording - Archived.mp4"));
-    createVideoAt(outputDirectory.resolve("recording - Archived.mp4"));
-    createVideoAt(archiveDirectory.resolve("recording - Archived.mp4"));
+    createVideoAt(inputDirectory.resolve("recording - Archived.mp4"), testVideo);
+    createVideoAt(outputDirectory.resolve("recording - Archived.mp4"), testVideo);
+    createVideoAt(archiveDirectory.resolve("recording - Archived.mp4"), testVideo);
 
     // When
     runApp(inputDirectory, outputDirectory, archiveDirectory);
@@ -475,17 +507,17 @@ class AppIntegrationTest {
     assertThatTestDirectory()
         .containsExactly(
             // encoding
-            outputDirectory.resolve("my video - CFR.mp4"),
+            new PathAndContents(outputDirectory.resolve("my video - CFR.mp4"), testVideoEncoded),
             // archive
-            archiveDirectory.resolve("my video - Archived.mp4"),
+            new PathAndContents(archiveDirectory.resolve("my video - Archived.mp4"), testVideo),
             // unrelated encodings
-            inputDirectory.resolve("recording - CFR.mp4"),
-            outputDirectory.resolve("recording - CFR.mp4"),
-            archiveDirectory.resolve("recording - CFR.mp4"),
+            new PathAndContents(inputDirectory.resolve("recording - CFR.mp4"), testVideoEncoded),
+            new PathAndContents(outputDirectory.resolve("recording - CFR.mp4"), testVideoEncoded),
+            new PathAndContents(archiveDirectory.resolve("recording - CFR.mp4"), testVideoEncoded),
             // unrelated archives
-            inputDirectory.resolve("recording - Archived.mp4"),
-            outputDirectory.resolve("recording - Archived.mp4"),
-            archiveDirectory.resolve("recording - Archived.mp4"));
+            new PathAndContents(inputDirectory.resolve("recording - Archived.mp4"), testVideo),
+            new PathAndContents(outputDirectory.resolve("recording - Archived.mp4"), testVideo),
+            new PathAndContents(archiveDirectory.resolve("recording - Archived.mp4"), testVideo));
   }
 
   @Test
@@ -494,10 +526,10 @@ class AppIntegrationTest {
     // Given
     // video to encode
     Path inputDirectory = createDirectoryAt(testDirectory.resolve("Gameplay"));
-    createVideoAt(inputDirectory.resolve("my video.mp4"));
+    createVideoAt(inputDirectory.resolve("my video.mp4"), testVideo);
 
     // already encoded
-    createVideoAt(inputDirectory.resolve("my video - CFR.mp4"));
+    createVideoAt(inputDirectory.resolve("my video - CFR.mp4"), testVideo);
 
     // When
     runApp(inputDirectory, inputDirectory, inputDirectory);
@@ -506,9 +538,9 @@ class AppIntegrationTest {
     assertThatTestDirectory()
         .containsExactly(
             // encoding
-            inputDirectory.resolve("my video - CFR.mp4"),
+            new PathAndContents(inputDirectory.resolve("my video - CFR.mp4"), testVideoEncoded),
             // archive
-            inputDirectory.resolve("my video - Archived.mp4"));
+            new PathAndContents(inputDirectory.resolve("my video - Archived.mp4"), testVideo));
   }
 
   @Test
@@ -517,10 +549,10 @@ class AppIntegrationTest {
     // Given
     // video to encode
     Path inputDirectory = createDirectoryAt(testDirectory.resolve("Gameplay"));
-    createVideoAt(inputDirectory.resolve("my video.mp4"));
+    createVideoAt(inputDirectory.resolve("my video.mp4"), testVideo);
 
     // already archived
-    createVideoAt(inputDirectory.resolve("my video - Archived.mp4"));
+    createVideoAt(inputDirectory.resolve("my video - Archived.mp4"), testVideo);
 
     // When
     runApp(inputDirectory, inputDirectory, inputDirectory);
@@ -529,9 +561,9 @@ class AppIntegrationTest {
     assertThatTestDirectory()
         .containsExactly(
             // encoding
-            inputDirectory.resolve("my video - CFR.mp4"),
+            new PathAndContents(inputDirectory.resolve("my video - CFR.mp4"), testVideoEncoded),
             // archive
-            inputDirectory.resolve("my video - Archived.mp4"));
+            new PathAndContents(inputDirectory.resolve("my video - Archived.mp4"), testVideo));
   }
 
   @Test
@@ -540,13 +572,13 @@ class AppIntegrationTest {
     // Given
     // video to encode
     Path inputDirectory = createDirectoryAt(testDirectory.resolve("Gameplay"));
-    createVideoAt(inputDirectory.resolve("my video.mp4"));
+    createVideoAt(inputDirectory.resolve("my video.mp4"), testVideo);
 
     // already encoded
-    createVideoAt(inputDirectory.resolve("my video - CFR.mp4"));
+    createVideoAt(inputDirectory.resolve("my video - CFR.mp4"), testVideo);
 
     // already archived
-    createVideoAt(inputDirectory.resolve("my video - Archived.mp4"));
+    createVideoAt(inputDirectory.resolve("my video - Archived.mp4"), testVideo);
 
     // When
     runApp(inputDirectory, inputDirectory, inputDirectory);
@@ -555,9 +587,9 @@ class AppIntegrationTest {
     assertThatTestDirectory()
         .containsExactly(
             // encoding
-            inputDirectory.resolve("my video - CFR.mp4"),
+            new PathAndContents(inputDirectory.resolve("my video - CFR.mp4"), testVideoEncoded),
             // archive
-            inputDirectory.resolve("my video - Archived.mp4"));
+            new PathAndContents(inputDirectory.resolve("my video - Archived.mp4"), testVideo));
   }
 
   @Test
@@ -566,10 +598,10 @@ class AppIntegrationTest {
     // Given
     // video to encode
     Path inputDirectory = createDirectoryAt(testDirectory.resolve("Gameplay"));
-    createVideoAt(inputDirectory.resolve("my video.mp4"));
+    createVideoAt(inputDirectory.resolve("my video.mp4"), testVideo);
 
     // already archived but different contents
-    createVideo2At(inputDirectory.resolve("my video - Archived.mp4"));
+    createVideoAt(inputDirectory.resolve("my video - Archived.mp4"), testVideo2);
 
     // When
     runApp(inputDirectory, inputDirectory, inputDirectory);
@@ -578,11 +610,11 @@ class AppIntegrationTest {
     assertThatTestDirectory()
         .containsExactly(
             // original
-            inputDirectory.resolve("my video.mp4"),
+            new PathAndContents(inputDirectory.resolve("my video.mp4"), testVideo),
             // encoding
-            inputDirectory.resolve("my video - CFR.mp4"),
+            new PathAndContents(inputDirectory.resolve("my video - CFR.mp4"), testVideoEncoded),
             // archive
-            inputDirectory.resolve("my video - Archived.mp4"));
+            new PathAndContents(inputDirectory.resolve("my video - Archived.mp4"), testVideo));
   }
 
   @Test
@@ -592,13 +624,13 @@ class AppIntegrationTest {
     // Given
     // video to encode
     Path inputDirectory = createDirectoryAt(testDirectory.resolve("Gameplay"));
-    createVideoAt(inputDirectory.resolve("my video.mp4"));
+    createVideoAt(inputDirectory.resolve("my video.mp4"), testVideo);
 
     // already encoded
-    createVideoAt(inputDirectory.resolve("my video - CFR.mp4"));
+    createVideoAt(inputDirectory.resolve("my video - CFR.mp4"), testVideo);
 
     // already archived but different contents
-    createVideo2At(inputDirectory.resolve("my video - Archived.mp4"));
+    createVideoAt(inputDirectory.resolve("my video - Archived.mp4"), testVideo2);
 
     // When
     runApp(inputDirectory, inputDirectory, inputDirectory);
@@ -607,11 +639,11 @@ class AppIntegrationTest {
     assertThatTestDirectory()
         .containsExactly(
             // original
-            inputDirectory.resolve("my video.mp4"),
+            new PathAndContents(inputDirectory.resolve("my video.mp4"), testVideo),
             // encoding
-            inputDirectory.resolve("my video - CFR.mp4"),
+            new PathAndContents(inputDirectory.resolve("my video - CFR.mp4"), testVideoEncoded),
             // archive
-            inputDirectory.resolve("my video - Archived.mp4"));
+            new PathAndContents(inputDirectory.resolve("my video - Archived.mp4"), testVideo));
   }
 
   @Test
@@ -622,36 +654,39 @@ class AppIntegrationTest {
     // Given
     // videos to encode
     Path inputDirectory = createDirectoryAt(testDirectory.resolve("Gameplay"));
-    createVideoAt(inputDirectory.resolve("recording1.mp4"));
-    createVideoAt(inputDirectory.resolve("recording2.mp4"));
-    createVideoAt(inputDirectory.resolve("Nested/recording3.mp4"));
-    createVideoAt(inputDirectory.resolve("Nested1/Nested2/recording4.mp4"));
+    createVideoAt(inputDirectory.resolve("recording1.mp4"), testVideo);
+    createVideoAt(inputDirectory.resolve("recording2.mp4"), testVideo);
+    createVideoAt(inputDirectory.resolve("Nested/recording3.mp4"), testVideo);
+    createVideoAt(inputDirectory.resolve("Nested1/Nested2/recording4.mp4"), testVideo);
 
     // already encoded
-    createVideoAt(inputDirectory.resolve("recording2 - CFR.mp4"));
-    createVideoAt(inputDirectory.resolve("Nested/recording3 - CFR.mp4"));
+    createVideoAt(inputDirectory.resolve("recording2 - CFR.mp4"), testVideo);
+    createVideoAt(inputDirectory.resolve("Nested/recording3 - CFR.mp4"), testVideo);
 
     // already archived
-    createVideoAt(inputDirectory.resolve("recording1 - Archived.mp4"));
-    createVideoAt(inputDirectory.resolve("Nested/recording3 - Archived.mp4"));
+    createVideoAt(inputDirectory.resolve("recording1 - Archived.mp4"), testVideo);
+    createVideoAt(inputDirectory.resolve("Nested/recording3 - Archived.mp4"), testVideo);
 
     // incomplete encodings
-    createVideoAt(inputDirectory.resolve("recording1 - CFR (incomplete).mp4"));
+    createVideoAt(inputDirectory.resolve("recording1 - CFR (incomplete).mp4"), testVideo);
     createVideoAt(
-        inputDirectory.resolve("Nested1/Nested2/Nested3/other video - CFR (incomplete).mp4"));
+        inputDirectory.resolve("Nested1/Nested2/Nested3/other video - CFR (incomplete).mp4"),
+        testVideo);
 
     // incomplete archives
-    createVideoAt(inputDirectory.resolve("recording2 - Archived (incomplete).mp4"));
+    createVideoAt(inputDirectory.resolve("recording2 - Archived (incomplete).mp4"), testVideo);
     createVideoAt(
-        inputDirectory.resolve("Nested1/Nested2/Nested3/random video - Archived (incomplete).mp4"));
+        inputDirectory.resolve("Nested1/Nested2/Nested3/random video - Archived (incomplete).mp4"),
+        testVideo);
 
     // unrelated encodings
-    createVideoAt(inputDirectory.resolve("Starcraft II/protoss - CFR.mp4"));
-    createVideoAt(inputDirectory.resolve("Starcraft II/Campaign/terran1 - CFR.mp4"));
+    createVideoAt(inputDirectory.resolve("Starcraft II/protoss - CFR.mp4"), testVideo);
+    createVideoAt(inputDirectory.resolve("Starcraft II/Campaign/terran1 - CFR.mp4"), testVideo);
 
     // unrelated archives
-    createVideoAt(inputDirectory.resolve("League of Legends/ryze - Archived.mp4"));
-    createVideoAt(inputDirectory.resolve("Path of Exile/Old builds/Discharge CoC - Archived.mp4"));
+    createVideoAt(inputDirectory.resolve("League of Legends/ryze - Archived.mp4"), testVideo);
+    createVideoAt(
+        inputDirectory.resolve("Path of Exile/Old builds/Discharge CoC - Archived.mp4"), testVideo);
 
     // When
     runApp(inputDirectory, inputDirectory, inputDirectory);
@@ -660,21 +695,29 @@ class AppIntegrationTest {
     assertThatTestDirectory()
         .containsExactly(
             // encodings
-            inputDirectory.resolve("recording1 - CFR.mp4"),
-            inputDirectory.resolve("recording2 - CFR.mp4"),
-            inputDirectory.resolve("Nested/recording3 - CFR.mp4"),
-            inputDirectory.resolve("Nested1/Nested2/recording4 - CFR.mp4"),
+            new PathAndContents(inputDirectory.resolve("recording1 - CFR.mp4"), testVideoEncoded),
+            new PathAndContents(inputDirectory.resolve("recording2 - CFR.mp4"), testVideoEncoded),
+            new PathAndContents(inputDirectory.resolve("Nested/recording3 - CFR.mp4"), testVideoEncoded),
+            new PathAndContents(
+                inputDirectory.resolve("Nested1/Nested2/recording4 - CFR.mp4"), testVideoEncoded),
             // archives
-            inputDirectory.resolve("recording1 - Archived.mp4"),
-            inputDirectory.resolve("recording2 - Archived.mp4"),
-            inputDirectory.resolve("Nested/recording3 - Archived.mp4"),
-            inputDirectory.resolve("Nested1/Nested2/recording4 - Archived.mp4"),
+            new PathAndContents(inputDirectory.resolve("recording1 - Archived.mp4"), testVideo),
+            new PathAndContents(inputDirectory.resolve("recording2 - Archived.mp4"), testVideo),
+            new PathAndContents(
+                inputDirectory.resolve("Nested/recording3 - Archived.mp4"), testVideo),
+            new PathAndContents(
+                inputDirectory.resolve("Nested1/Nested2/recording4 - Archived.mp4"), testVideo),
             // unrelated encodings
-            inputDirectory.resolve("Starcraft II/protoss - CFR.mp4"),
-            inputDirectory.resolve("Starcraft II/Campaign/terran1 - CFR.mp4"),
+            new PathAndContents(
+                inputDirectory.resolve("Starcraft II/protoss - CFR.mp4"), testVideoEncoded),
+            new PathAndContents(
+                inputDirectory.resolve("Starcraft II/Campaign/terran1 - CFR.mp4"), testVideoEncoded),
             // unrelated archives
-            inputDirectory.resolve("League of Legends/ryze - Archived.mp4"),
-            inputDirectory.resolve("Path of Exile/Old builds/Discharge CoC - Archived.mp4"));
+            new PathAndContents(
+                inputDirectory.resolve("League of Legends/ryze - Archived.mp4"), testVideo),
+            new PathAndContents(
+                inputDirectory.resolve("Path of Exile/Old builds/Discharge CoC - Archived.mp4"),
+                testVideo));
   }
 
   @Test
@@ -685,42 +728,42 @@ class AppIntegrationTest {
     // Given
     // videos to encode
     Path inputDirectory = createDirectoryAt(testDirectory.resolve("Gameplay"));
-    createVideoAt(inputDirectory.resolve("recording1.mp4"));
-    createVideoAt(inputDirectory.resolve("recording2.mp4"));
-    createVideoAt(inputDirectory.resolve("Nested/recording3.mp4"));
-    createVideoAt(inputDirectory.resolve("Nested1/Nested2/recording4.mp4"));
+    createVideoAt(inputDirectory.resolve("recording1.mp4"), testVideo);
+    createVideoAt(inputDirectory.resolve("recording2.mp4"), testVideo);
+    createVideoAt(inputDirectory.resolve("Nested/recording3.mp4"), testVideo);
+    createVideoAt(inputDirectory.resolve("Nested1/Nested2/recording4.mp4"), testVideo);
 
     Path outputDirectory = createDirectoryAt(testDirectory.resolve("Gameplay Encoded"));
 
     Path archiveDirectory = createDirectoryAt(testDirectory.resolve("Gameplay Archive"));
 
     // already encoded
-    createVideoAt(outputDirectory.resolve("recording2 - CFR.mp4"));
-    createVideoAt(outputDirectory.resolve("Nested/recording3 - CFR.mp4"));
+    createVideoAt(outputDirectory.resolve("recording2 - CFR.mp4"), testVideo);
+    createVideoAt(outputDirectory.resolve("Nested/recording3 - CFR.mp4"), testVideo);
 
     // already archived
-    createVideoAt(archiveDirectory.resolve("recording1 - Archived.mp4"));
-    createVideoAt(archiveDirectory.resolve("Nested/recording3 - Archived.mp4"));
+    createVideoAt(archiveDirectory.resolve("recording1 - Archived.mp4"), testVideo);
+    createVideoAt(archiveDirectory.resolve("Nested/recording3 - Archived.mp4"), testVideo);
 
     // incomplete encodings
-    createVideoAt(inputDirectory.resolve("recording1 - CFR (incomplete).mp4"));
-    createVideoAt(outputDirectory.resolve("recording1 - CFR (incomplete).mp4"));
-    createVideoAt(archiveDirectory.resolve("recording1 - CFR (incomplete).mp4"));
+    createVideoAt(inputDirectory.resolve("recording1 - CFR (incomplete).mp4"), testVideo);
+    createVideoAt(outputDirectory.resolve("recording1 - CFR (incomplete).mp4"), testVideo);
+    createVideoAt(archiveDirectory.resolve("recording1 - CFR (incomplete).mp4"), testVideo);
 
     // incomplete archives
-    createVideoAt(inputDirectory.resolve("recording2 - Archived (incomplete).mp4"));
-    createVideoAt(outputDirectory.resolve("recording2 - Archived (incomplete).mp4"));
-    createVideoAt(archiveDirectory.resolve("recording2 - Archived (incomplete).mp4"));
+    createVideoAt(inputDirectory.resolve("recording2 - Archived (incomplete).mp4"), testVideo);
+    createVideoAt(outputDirectory.resolve("recording2 - Archived (incomplete).mp4"), testVideo);
+    createVideoAt(archiveDirectory.resolve("recording2 - Archived (incomplete).mp4"), testVideo);
 
     // unrelated encodings
-    createVideoAt(inputDirectory.resolve("recording - CFR.mp4"));
-    createVideoAt(outputDirectory.resolve("recording - CFR.mp4"));
-    createVideoAt(archiveDirectory.resolve("recording - CFR.mp4"));
+    createVideoAt(inputDirectory.resolve("recording - CFR.mp4"), testVideo);
+    createVideoAt(outputDirectory.resolve("recording - CFR.mp4"), testVideo);
+    createVideoAt(archiveDirectory.resolve("recording - CFR.mp4"), testVideo);
 
     // unrelated archives
-    createVideoAt(inputDirectory.resolve("recording - Archived.mp4"));
-    createVideoAt(outputDirectory.resolve("recording - Archived.mp4"));
-    createVideoAt(archiveDirectory.resolve("recording - Archived.mp4"));
+    createVideoAt(inputDirectory.resolve("recording - Archived.mp4"), testVideo);
+    createVideoAt(outputDirectory.resolve("recording - Archived.mp4"), testVideo);
+    createVideoAt(archiveDirectory.resolve("recording - Archived.mp4"), testVideo);
 
     // When
     runApp(inputDirectory, outputDirectory, archiveDirectory);
@@ -729,23 +772,26 @@ class AppIntegrationTest {
     assertThatTestDirectory()
         .containsExactly(
             // encodings
-            outputDirectory.resolve("recording1 - CFR.mp4"),
-            outputDirectory.resolve("recording2 - CFR.mp4"),
-            outputDirectory.resolve("Nested/recording3 - CFR.mp4"),
-            outputDirectory.resolve("Nested1/Nested2/recording4 - CFR.mp4"),
+            new PathAndContents(outputDirectory.resolve("recording1 - CFR.mp4"), testVideoEncoded),
+            new PathAndContents(outputDirectory.resolve("recording2 - CFR.mp4"), testVideoEncoded),
+            new PathAndContents(outputDirectory.resolve("Nested/recording3 - CFR.mp4"), testVideoEncoded),
+            new PathAndContents(
+                outputDirectory.resolve("Nested1/Nested2/recording4 - CFR.mp4"), testVideoEncoded),
             // archives
-            archiveDirectory.resolve("recording1 - Archived.mp4"),
-            archiveDirectory.resolve("recording2 - Archived.mp4"),
-            archiveDirectory.resolve("Nested/recording3 - Archived.mp4"),
-            archiveDirectory.resolve("Nested1/Nested2/recording4 - Archived.mp4"),
+            new PathAndContents(archiveDirectory.resolve("recording1 - Archived.mp4"), testVideo),
+            new PathAndContents(archiveDirectory.resolve("recording2 - Archived.mp4"), testVideo),
+            new PathAndContents(
+                archiveDirectory.resolve("Nested/recording3 - Archived.mp4"), testVideo),
+            new PathAndContents(
+                archiveDirectory.resolve("Nested1/Nested2/recording4 - Archived.mp4"), testVideo),
             // unrelated encodings
-            inputDirectory.resolve("recording - CFR.mp4"),
-            outputDirectory.resolve("recording - CFR.mp4"),
-            archiveDirectory.resolve("recording - CFR.mp4"),
+            new PathAndContents(inputDirectory.resolve("recording - CFR.mp4"), testVideoEncoded),
+            new PathAndContents(outputDirectory.resolve("recording - CFR.mp4"), testVideoEncoded),
+            new PathAndContents(archiveDirectory.resolve("recording - CFR.mp4"), testVideoEncoded),
             // unrelated archives
-            inputDirectory.resolve("recording - Archived.mp4"),
-            outputDirectory.resolve("recording - Archived.mp4"),
-            archiveDirectory.resolve("recording - Archived.mp4"));
+            new PathAndContents(inputDirectory.resolve("recording - Archived.mp4"), testVideo),
+            new PathAndContents(outputDirectory.resolve("recording - Archived.mp4"), testVideo),
+            new PathAndContents(archiveDirectory.resolve("recording - Archived.mp4"), testVideo));
   }
 
   @CanIgnoreReturnValue
@@ -757,16 +803,9 @@ class AppIntegrationTest {
   }
 
   @CanIgnoreReturnValue
-  private Path createVideoAt(Path path) throws IOException {
+  private Path createVideoAt(Path path, Path videoToCopy) throws IOException {
     Files.createDirectories(checkNotNull(path.getParent()));
-    Files.copy(testVideo, path);
-    return path;
-  }
-
-  @CanIgnoreReturnValue
-  private Path createVideo2At(Path path) throws IOException {
-    Files.createDirectories(checkNotNull(path.getParent()));
-    Files.copy(testVideo2, path);
+    Files.copy(videoToCopy, path);
     return path;
   }
 
@@ -778,7 +817,52 @@ class AppIntegrationTest {
         Boolean.FALSE.toString());
   }
 
-  private StreamSubject assertThatTestDirectory() throws IOException {
-    return assertThat(Files.walk(testDirectory).filter(Files::isRegularFile));
+  private IterableSubject.UsingCorrespondence<PathAndContents, PathAndContents>
+      assertThatTestDirectory() throws IOException {
+    return assertThat(
+            Files.walk(testDirectory)
+                .filter(Files::isRegularFile)
+                .map(path -> new PathAndContents(path, path))
+                .toList())
+        .comparingElementsUsing(PathAndContents.correspondence());
+  }
+
+  private record PathAndContents(Path path, Path contents) {
+
+    // HandBrake is not deterministic (repeating an encoding doesn't always result in the same output)
+    // workaround when asserting expected file contents:
+    // Just check the first ~1MB is equal. Good enough for these test, if it were an entirely different file it would fail on the first byte.
+    // TODO better workaround? - Call mismatch several times? Check 95% equal?
+    static int FIRST_MISMATCHED_BYTE_TOLERANCE = 1_000_000;
+
+    static Correspondence<PathAndContents, PathAndContents> correspondence() {
+      return Correspondence.from(PathAndContents::recordsEquivalent, "is equivalent to")
+          .formattingDiffsUsing(PathAndContents::formatRecordDiff);
+    }
+
+    static boolean recordsEquivalent(PathAndContents actual, PathAndContents expected) {
+      try {
+        return actual.path.equals(expected.path)
+            && Files.mismatch(actual.contents, expected.contents) <= FIRST_MISMATCHED_BYTE_TOLERANCE;
+      } catch (IOException e) {
+        throw new UncheckedIOException(e);
+      }
+    }
+
+    static String formatRecordDiff(PathAndContents actual, PathAndContents expected) {
+      if (!actual.path.equals(expected.path)) {
+        return "paths not equal";
+      }
+      try {
+        long mismatch = Files.mismatch(actual.contents, expected.contents);
+        if (mismatch > FIRST_MISMATCHED_BYTE_TOLERANCE) {
+          return "contents differ, first mismatched byte: %s"
+              .formatted(mismatch);
+        }
+        throw new AssertionError("Unreachable");
+      } catch (IOException e) {
+        throw new UncheckedIOException(e);
+      }
+    }
   }
 }

--- a/nvidia-shadowplay/src/integrationTest/java/com/wilmol/handbrake/nvidia/shadowplay/AppIntegrationTest.java
+++ b/nvidia-shadowplay/src/integrationTest/java/com/wilmol/handbrake/nvidia/shadowplay/AppIntegrationTest.java
@@ -3,7 +3,6 @@ package com.wilmol.handbrake.nvidia.shadowplay;
 import static com.google.common.base.Preconditions.checkNotNull;
 import static com.google.common.truth.Truth.assertThat;
 
-import com.google.common.collect.Lists;
 import com.google.common.io.Resources;
 import com.google.common.truth.Correspondence;
 import com.google.common.truth.IterableSubject;
@@ -12,8 +11,7 @@ import java.io.IOException;
 import java.io.UncheckedIOException;
 import java.nio.file.Files;
 import java.nio.file.Path;
-import java.util.Arrays;
-
+import java.util.stream.IntStream;
 import org.apache.commons.io.FileUtils;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
@@ -41,7 +39,10 @@ class AppIntegrationTest {
   void setUp() throws Exception {
     testDirectory = Path.of(this.getClass().getSimpleName());
     testVideo = Path.of(Resources.getResource("Big_Buck_Bunny_360_10s_1MB.mp4").toURI());
-    testVideoEncoded = Path.of(Resources.getResource("Big_Buck_Bunny_360_10s_1MB_encoded_Production_Standard.mp4").toURI());
+    testVideoEncoded =
+        Path.of(
+            Resources.getResource("Big_Buck_Bunny_360_10s_1MB_encoded_Production_Standard.mp4")
+                .toURI());
     testVideo2 = Path.of(Resources.getResource("Big_Buck_Bunny_360_10s_2MB.mp4").toURI());
   }
 
@@ -154,7 +155,8 @@ class AppIntegrationTest {
         .containsExactly(
             // encoding
             new PathAndContents(
-                inputDirectory.resolve("League of Legends/ranked_game1 - CFR.mp4"), testVideoEncoded),
+                inputDirectory.resolve("League of Legends/ranked_game1 - CFR.mp4"),
+                testVideoEncoded),
             // archive
             new PathAndContents(
                 inputDirectory.resolve("League of Legends/ranked_game1 - Archived.mp4"),
@@ -203,7 +205,8 @@ class AppIntegrationTest {
         .containsExactly(
             // encoding
             new PathAndContents(
-                inputDirectory.resolve("Path of Exile/vaal spark templar - CFR.mp4"), testVideoEncoded),
+                inputDirectory.resolve("Path of Exile/vaal spark templar - CFR.mp4"),
+                testVideoEncoded),
             // archive
             new PathAndContents(
                 archiveDirectory.resolve("Path of Exile/vaal spark templar - Archived.mp4"),
@@ -261,7 +264,8 @@ class AppIntegrationTest {
             // encodings
             new PathAndContents(inputDirectory.resolve("recording1 - CFR.mp4"), testVideoEncoded),
             new PathAndContents(inputDirectory.resolve("recording2 - CFR.mp4"), testVideoEncoded),
-            new PathAndContents(inputDirectory.resolve("Nested/recording3 - CFR.mp4"), testVideoEncoded),
+            new PathAndContents(
+                inputDirectory.resolve("Nested/recording3 - CFR.mp4"), testVideoEncoded),
             new PathAndContents(
                 inputDirectory.resolve("Nested1/Nested2/recording4 - CFR.mp4"), testVideoEncoded),
             // archives
@@ -295,7 +299,8 @@ class AppIntegrationTest {
             // encodings
             new PathAndContents(outputDirectory.resolve("recording1 - CFR.mp4"), testVideoEncoded),
             new PathAndContents(outputDirectory.resolve("recording2 - CFR.mp4"), testVideoEncoded),
-            new PathAndContents(outputDirectory.resolve("Nested/recording3 - CFR.mp4"), testVideoEncoded),
+            new PathAndContents(
+                outputDirectory.resolve("Nested/recording3 - CFR.mp4"), testVideoEncoded),
             new PathAndContents(
                 outputDirectory.resolve("Nested1/Nested2/recording4 - CFR.mp4"), testVideoEncoded),
             // archives
@@ -329,7 +334,8 @@ class AppIntegrationTest {
             // encodings
             new PathAndContents(inputDirectory.resolve("recording1 - CFR.mp4"), testVideoEncoded),
             new PathAndContents(inputDirectory.resolve("recording2 - CFR.mp4"), testVideoEncoded),
-            new PathAndContents(inputDirectory.resolve("Nested/recording3 - CFR.mp4"), testVideoEncoded),
+            new PathAndContents(
+                inputDirectory.resolve("Nested/recording3 - CFR.mp4"), testVideoEncoded),
             new PathAndContents(
                 inputDirectory.resolve("Nested1/Nested2/recording4 - CFR.mp4"), testVideoEncoded),
             // archives
@@ -366,7 +372,8 @@ class AppIntegrationTest {
             // encodings
             new PathAndContents(outputDirectory.resolve("recording1 - CFR.mp4"), testVideoEncoded),
             new PathAndContents(outputDirectory.resolve("recording2 - CFR.mp4"), testVideoEncoded),
-            new PathAndContents(outputDirectory.resolve("Nested/recording3 - CFR.mp4"), testVideoEncoded),
+            new PathAndContents(
+                outputDirectory.resolve("Nested/recording3 - CFR.mp4"), testVideoEncoded),
             new PathAndContents(
                 outputDirectory.resolve("Nested1/Nested2/recording4 - CFR.mp4"), testVideoEncoded),
             // archives
@@ -451,8 +458,8 @@ class AppIntegrationTest {
     createVideoAt(inputDirectory.resolve("my video.mp4"), testVideo);
 
     // unrelated encodings
-    createVideoAt(inputDirectory.resolve("recording - CFR.mp4"), testVideo);
-    createVideoAt(inputDirectory.resolve("recording2 - CFR.mp4"), testVideo);
+    createVideoAt(inputDirectory.resolve("recording - CFR.mp4"), testVideoEncoded);
+    createVideoAt(inputDirectory.resolve("recording2 - CFR.mp4"), testVideoEncoded);
 
     // unrelated archives
     createVideoAt(inputDirectory.resolve("recording - Archived.mp4"), testVideo);
@@ -529,7 +536,7 @@ class AppIntegrationTest {
     createVideoAt(inputDirectory.resolve("my video.mp4"), testVideo);
 
     // already encoded
-    createVideoAt(inputDirectory.resolve("my video - CFR.mp4"), testVideo);
+    createVideoAt(inputDirectory.resolve("my video - CFR.mp4"), testVideoEncoded);
 
     // When
     runApp(inputDirectory, inputDirectory, inputDirectory);
@@ -575,7 +582,7 @@ class AppIntegrationTest {
     createVideoAt(inputDirectory.resolve("my video.mp4"), testVideo);
 
     // already encoded
-    createVideoAt(inputDirectory.resolve("my video - CFR.mp4"), testVideo);
+    createVideoAt(inputDirectory.resolve("my video - CFR.mp4"), testVideoEncoded);
 
     // already archived
     createVideoAt(inputDirectory.resolve("my video - Archived.mp4"), testVideo);
@@ -614,7 +621,7 @@ class AppIntegrationTest {
             // encoding
             new PathAndContents(inputDirectory.resolve("my video - CFR.mp4"), testVideoEncoded),
             // archive
-            new PathAndContents(inputDirectory.resolve("my video - Archived.mp4"), testVideo));
+            new PathAndContents(inputDirectory.resolve("my video - Archived.mp4"), testVideo2));
   }
 
   @Test
@@ -627,7 +634,7 @@ class AppIntegrationTest {
     createVideoAt(inputDirectory.resolve("my video.mp4"), testVideo);
 
     // already encoded
-    createVideoAt(inputDirectory.resolve("my video - CFR.mp4"), testVideo);
+    createVideoAt(inputDirectory.resolve("my video - CFR.mp4"), testVideoEncoded);
 
     // already archived but different contents
     createVideoAt(inputDirectory.resolve("my video - Archived.mp4"), testVideo2);
@@ -643,7 +650,7 @@ class AppIntegrationTest {
             // encoding
             new PathAndContents(inputDirectory.resolve("my video - CFR.mp4"), testVideoEncoded),
             // archive
-            new PathAndContents(inputDirectory.resolve("my video - Archived.mp4"), testVideo));
+            new PathAndContents(inputDirectory.resolve("my video - Archived.mp4"), testVideo2));
   }
 
   @Test
@@ -660,8 +667,8 @@ class AppIntegrationTest {
     createVideoAt(inputDirectory.resolve("Nested1/Nested2/recording4.mp4"), testVideo);
 
     // already encoded
-    createVideoAt(inputDirectory.resolve("recording2 - CFR.mp4"), testVideo);
-    createVideoAt(inputDirectory.resolve("Nested/recording3 - CFR.mp4"), testVideo);
+    createVideoAt(inputDirectory.resolve("recording2 - CFR.mp4"), testVideoEncoded);
+    createVideoAt(inputDirectory.resolve("Nested/recording3 - CFR.mp4"), testVideoEncoded);
 
     // already archived
     createVideoAt(inputDirectory.resolve("recording1 - Archived.mp4"), testVideo);
@@ -680,8 +687,9 @@ class AppIntegrationTest {
         testVideo);
 
     // unrelated encodings
-    createVideoAt(inputDirectory.resolve("Starcraft II/protoss - CFR.mp4"), testVideo);
-    createVideoAt(inputDirectory.resolve("Starcraft II/Campaign/terran1 - CFR.mp4"), testVideo);
+    createVideoAt(inputDirectory.resolve("Starcraft II/protoss - CFR.mp4"), testVideoEncoded);
+    createVideoAt(
+        inputDirectory.resolve("Starcraft II/Campaign/terran1 - CFR.mp4"), testVideoEncoded);
 
     // unrelated archives
     createVideoAt(inputDirectory.resolve("League of Legends/ryze - Archived.mp4"), testVideo);
@@ -697,7 +705,8 @@ class AppIntegrationTest {
             // encodings
             new PathAndContents(inputDirectory.resolve("recording1 - CFR.mp4"), testVideoEncoded),
             new PathAndContents(inputDirectory.resolve("recording2 - CFR.mp4"), testVideoEncoded),
-            new PathAndContents(inputDirectory.resolve("Nested/recording3 - CFR.mp4"), testVideoEncoded),
+            new PathAndContents(
+                inputDirectory.resolve("Nested/recording3 - CFR.mp4"), testVideoEncoded),
             new PathAndContents(
                 inputDirectory.resolve("Nested1/Nested2/recording4 - CFR.mp4"), testVideoEncoded),
             // archives
@@ -711,7 +720,8 @@ class AppIntegrationTest {
             new PathAndContents(
                 inputDirectory.resolve("Starcraft II/protoss - CFR.mp4"), testVideoEncoded),
             new PathAndContents(
-                inputDirectory.resolve("Starcraft II/Campaign/terran1 - CFR.mp4"), testVideoEncoded),
+                inputDirectory.resolve("Starcraft II/Campaign/terran1 - CFR.mp4"),
+                testVideoEncoded),
             // unrelated archives
             new PathAndContents(
                 inputDirectory.resolve("League of Legends/ryze - Archived.mp4"), testVideo),
@@ -738,8 +748,8 @@ class AppIntegrationTest {
     Path archiveDirectory = createDirectoryAt(testDirectory.resolve("Gameplay Archive"));
 
     // already encoded
-    createVideoAt(outputDirectory.resolve("recording2 - CFR.mp4"), testVideo);
-    createVideoAt(outputDirectory.resolve("Nested/recording3 - CFR.mp4"), testVideo);
+    createVideoAt(outputDirectory.resolve("recording2 - CFR.mp4"), testVideoEncoded);
+    createVideoAt(outputDirectory.resolve("Nested/recording3 - CFR.mp4"), testVideoEncoded);
 
     // already archived
     createVideoAt(archiveDirectory.resolve("recording1 - Archived.mp4"), testVideo);
@@ -756,9 +766,9 @@ class AppIntegrationTest {
     createVideoAt(archiveDirectory.resolve("recording2 - Archived (incomplete).mp4"), testVideo);
 
     // unrelated encodings
-    createVideoAt(inputDirectory.resolve("recording - CFR.mp4"), testVideo);
-    createVideoAt(outputDirectory.resolve("recording - CFR.mp4"), testVideo);
-    createVideoAt(archiveDirectory.resolve("recording - CFR.mp4"), testVideo);
+    createVideoAt(inputDirectory.resolve("recording - CFR.mp4"), testVideoEncoded);
+    createVideoAt(outputDirectory.resolve("recording - CFR.mp4"), testVideoEncoded);
+    createVideoAt(archiveDirectory.resolve("recording - CFR.mp4"), testVideoEncoded);
 
     // unrelated archives
     createVideoAt(inputDirectory.resolve("recording - Archived.mp4"), testVideo);
@@ -774,7 +784,8 @@ class AppIntegrationTest {
             // encodings
             new PathAndContents(outputDirectory.resolve("recording1 - CFR.mp4"), testVideoEncoded),
             new PathAndContents(outputDirectory.resolve("recording2 - CFR.mp4"), testVideoEncoded),
-            new PathAndContents(outputDirectory.resolve("Nested/recording3 - CFR.mp4"), testVideoEncoded),
+            new PathAndContents(
+                outputDirectory.resolve("Nested/recording3 - CFR.mp4"), testVideoEncoded),
             new PathAndContents(
                 outputDirectory.resolve("Nested1/Nested2/recording4 - CFR.mp4"), testVideoEncoded),
             // archives
@@ -829,37 +840,43 @@ class AppIntegrationTest {
 
   private record PathAndContents(Path path, Path contents) {
 
-    // HandBrake is not deterministic (repeating an encoding doesn't always result in the same output)
-    // workaround when asserting expected file contents:
-    // Just check the first ~1MB is equal. Good enough for these test, if it were an entirely different file it would fail on the first byte.
-    // TODO better workaround? - Call mismatch several times? Check 95% equal?
-    static int FIRST_MISMATCHED_BYTE_TOLERANCE = 1_000_000;
-
     static Correspondence<PathAndContents, PathAndContents> correspondence() {
       return Correspondence.from(PathAndContents::recordsEquivalent, "is equivalent to")
           .formattingDiffsUsing(PathAndContents::formatRecordDiff);
     }
 
     static boolean recordsEquivalent(PathAndContents actual, PathAndContents expected) {
-      try {
-        return actual.path.equals(expected.path)
-            && Files.mismatch(actual.contents, expected.contents) <= FIRST_MISMATCHED_BYTE_TOLERANCE;
-      } catch (IOException e) {
-        throw new UncheckedIOException(e);
-      }
+      return actual.path.equals(expected.path)
+          && contentsSimilar(actual.contents, expected.contents);
     }
 
     static String formatRecordDiff(PathAndContents actual, PathAndContents expected) {
       if (!actual.path.equals(expected.path)) {
         return "paths not equal";
       }
+      if (!contentsSimilar(actual.path, expected.path)) {
+        return "contents not similar";
+      }
+      throw new AssertionError("Unreachable");
+    }
+
+    // HandBrake is not deterministic (encoding doesn't always produce the exact same output)
+    // so need a method to test file contents are similar.
+    // This method returns true if <1% bytes mismatch, which is good enough for these tests.
+    static boolean contentsSimilar(Path a, Path b) {
       try {
-        long mismatch = Files.mismatch(actual.contents, expected.contents);
-        if (mismatch > FIRST_MISMATCHED_BYTE_TOLERANCE) {
-          return "contents differ, first mismatched byte: %s"
-              .formatted(mismatch);
-        }
-        throw new AssertionError("Unreachable");
+        byte[] aBytes = Files.readAllBytes(a);
+        byte[] bBytes = Files.readAllBytes(b);
+
+        long mismatchCount =
+            IntStream.iterate(0, i -> i < aBytes.length && i < bBytes.length, i -> i + 1)
+                .filter(i -> aBytes[i] != bBytes[i])
+                .count();
+
+        double meanLength = (aBytes.length + bBytes.length) / 2d;
+
+        double percentMismatch = mismatchCount / meanLength;
+        return percentMismatch < 0.01;
       } catch (IOException e) {
         throw new UncheckedIOException(e);
       }


### PR DESCRIPTION
Now asserts expected file path and contents in integration tests.

I.e. archived file contents should match original file contents, and encoded file contents should match expected encoded video.